### PR TITLE
Add trait method for creating an integration

### DIFF
--- a/core/src/model/integration.rs
+++ b/core/src/model/integration.rs
@@ -10,3 +10,8 @@ impl PartialEq for Integration {
         self.id == other.id
     }
 }
+
+pub struct NewIntegration {
+    pub webhook_url: String,
+    pub success_url: String,
+}

--- a/core/src/model/integration.rs
+++ b/core/src/model/integration.rs
@@ -1,9 +1,6 @@
-use crate::model::User;
-
 #[derive(Clone, Debug)]
 pub struct Integration {
     pub id: i32,
-    pub owner: User,
     pub webhook_url: String,
     pub success_url: String,
 }

--- a/core/src/model/mod.rs
+++ b/core/src/model/mod.rs
@@ -3,5 +3,5 @@ mod integration;
 mod user;
 
 pub use authorization::Authorization;
-pub use integration::Integration;
+pub use integration::{Integration, NewIntegration};
 pub use user::User;

--- a/core/src/repo/integration_repo.rs
+++ b/core/src/repo/integration_repo.rs
@@ -2,9 +2,13 @@ use std::error::Error;
 
 use async_trait::async_trait;
 
-use crate::model::Integration;
+use crate::model::{Integration, NewIntegration};
 
 #[async_trait]
 pub trait IntegrationRepo {
     async fn find(&self, integration_id: i32) -> Result<Option<Integration>, Box<dyn Error>>;
+    async fn create(
+        &mut self,
+        new_integration: NewIntegration,
+    ) -> Result<Integration, Box<dyn Error>>;
 }

--- a/support/src/fixtures/mod.rs
+++ b/support/src/fixtures/mod.rs
@@ -3,5 +3,5 @@ mod test_integration;
 mod test_user;
 
 pub use test_authorization::TestAuthorization;
-pub use test_integration::TestIntegration;
+pub use test_integration::{TestIntegration, TestNewIntegration};
 pub use test_user::TestUser;

--- a/support/src/fixtures/test_integration.rs
+++ b/support/src/fixtures/test_integration.rs
@@ -24,3 +24,22 @@ impl TestIntegration {
         self.integration
     }
 }
+
+pub struct TestNewIntegration {
+    new_integration: NewIntegration,
+}
+
+impl TestNewIntegration {
+    pub fn new() -> Self {
+        Self {
+            new_integration: NewIntegration {
+                webhook_url: "https://test-webhook.com".into(),
+                success_url: "https://test-success.com".into(),
+            },
+        }
+    }
+
+    pub fn build(self) -> NewIntegration {
+        self.new_integration
+    }
+}

--- a/support/src/fixtures/test_integration.rs
+++ b/support/src/fixtures/test_integration.rs
@@ -1,7 +1,5 @@
 use lfg_core::model::Integration;
 
-use super::TestUser;
-
 pub struct TestIntegration {
     integration: Integration,
 }
@@ -11,7 +9,6 @@ impl TestIntegration {
         Self {
             integration: Integration {
                 id: 1,
-                owner: TestUser::new().build(),
                 webhook_url: "https://test-webhook.com".into(),
                 success_url: "https://test-success.com".into(),
             },

--- a/support/src/repo/in_memory_integration_repo.rs
+++ b/support/src/repo/in_memory_integration_repo.rs
@@ -3,7 +3,10 @@ use std::error::Error;
 
 use async_trait::async_trait;
 
-use lfg_core::{model::Integration, repo::IntegrationRepo};
+use lfg_core::{
+    model::{Integration, NewIntegration},
+    repo::IntegrationRepo,
+};
 
 pub struct InMemoryIntegrationRepo {
     integrations: HashMap<i32, Integration>,
@@ -20,11 +23,24 @@ impl IntegrationRepo for InMemoryIntegrationRepo {
     async fn find(&self, integration_id: i32) -> Result<Option<Integration>, Box<dyn Error>> {
         Ok(self.integrations.get(&integration_id).cloned())
     }
+
+    async fn create(
+        &mut self,
+        new_integration: NewIntegration,
+    ) -> Result<Integration, Box<dyn Error>> {
+        let integration = Integration {
+            id: 1,
+            success_url: new_integration.success_url,
+            webhook_url: new_integration.webhook_url,
+        };
+        self.integrations.insert(1, integration.clone());
+        Ok(integration)
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::fixtures::TestIntegration;
+    use crate::fixtures::{TestIntegration, TestNewIntegration};
 
     use super::*;
 
@@ -46,5 +62,15 @@ mod tests {
         let option = repo.find(1).await.unwrap();
 
         assert_eq!(option, Some(integration));
+    }
+
+    #[tokio::test]
+    async fn create() {
+        let mut repo = InMemoryIntegrationRepo::new(HashMap::new());
+        let new_integration = TestNewIntegration::new().build();
+
+        let integration = repo.create(new_integration).await.unwrap();
+
+        assert_eq!(repo.find(integration.id).await.unwrap(), Some(integration));
     }
 }


### PR DESCRIPTION
When it comes time to create an integration via the API, our repository will need to know how to create the integration.