### PR TITLE
Add Postgres integration repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "core",
+    "hold",
     "support",
     "web",
 ]

--- a/hold/Cargo.toml
+++ b/hold/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "lfg_hold"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/hold/Cargo.toml
+++ b/hold/Cargo.toml
@@ -6,3 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait = "~0.1"
+lfg-core = { path = "../core" }
+lfg-support = { path = "../support" }
+sqlx = { version = "0.6", features = [ "runtime-tokio-native-tls" , "postgres" ] }
+tokio = { version = "1.0", features = ["full"] }

--- a/hold/migrations/20220713044015_create_integrations_table.sql
+++ b/hold/migrations/20220713044015_create_integrations_table.sql
@@ -1,0 +1,6 @@
+-- Add migration script here
+CREATE TABLE integrations(
+  id SERIAL PRIMARY KEY,
+  webhook_url TEXT not null,
+  success_url TEXT not null
+)

--- a/hold/src/lib.rs
+++ b/hold/src/lib.rs
@@ -1,0 +1,8 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        let result = 2 + 2;
+        assert_eq!(result, 4);
+    }
+}

--- a/hold/src/lib.rs
+++ b/hold/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod repo;
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/hold/src/repo/mod.rs
+++ b/hold/src/repo/mod.rs
@@ -1,0 +1,3 @@
+mod psql_integration_repo;
+
+pub use psql_integration_repo::PsqlIntegrationRepo;

--- a/hold/src/repo/psql_integration_repo.rs
+++ b/hold/src/repo/psql_integration_repo.rs
@@ -1,0 +1,53 @@
+use async_trait::async_trait;
+use std::error::Error;
+
+use sqlx::{Pool, Postgres};
+
+use lfg_core::{
+    model::{Integration, NewIntegration},
+    repo::IntegrationRepo,
+};
+
+pub struct PsqlIntegrationRepo {
+    pool: Pool<Postgres>,
+}
+
+impl PsqlIntegrationRepo {
+    pub fn new(pool: Pool<Postgres>) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl IntegrationRepo for PsqlIntegrationRepo {
+    async fn find(&self, integration_id: i32) -> Result<Option<Integration>, Box<dyn Error>> {
+        let integration = sqlx::query_as!(
+            Integration,
+            "SELECT * FROM integrations WHERE id = $1",
+            integration_id
+        )
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(integration)
+    }
+    async fn create(
+        &mut self,
+        new_integration: NewIntegration,
+    ) -> Result<Integration, Box<dyn Error>> {
+        let integration = sqlx::query_as!(
+            Integration,
+            r#"
+            INSERT INTO integrations(success_url, webhook_url)
+            VALUES ($1, $2)
+            RETURNING *
+            "#,
+            new_integration.success_url,
+            new_integration.webhook_url
+        )
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(integration)
+    }
+}

--- a/hold/tests/integration_repo.rs
+++ b/hold/tests/integration_repo.rs
@@ -1,0 +1,51 @@
+use lfg_core::repo::IntegrationRepo;
+use lfg_hold::repo::PsqlIntegrationRepo;
+use lfg_support::fixtures::TestNewIntegration;
+use sqlx::postgres::PgPoolOptions;
+
+#[tokio::test]
+async fn find_empty() -> Result<(), sqlx::Error> {
+    let pool = PgPoolOptions::new()
+        .connect("postgres://jgayfer:@localhost/lfg")
+        .await?;
+    let repo = PsqlIntegrationRepo::new(pool);
+
+    let found_integration = repo.find(117).await.unwrap();
+
+    assert!(found_integration.is_none());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn find_with_result() -> Result<(), sqlx::Error> {
+    let pool = PgPoolOptions::new()
+        .connect("postgres://jgayfer:@localhost/lfg")
+        .await?;
+    let mut repo = PsqlIntegrationRepo::new(pool);
+    let new_integration = TestNewIntegration::new().build();
+
+    let created_integration = repo.create(new_integration).await.unwrap();
+
+    let found_integration = repo.find(created_integration.id).await.unwrap().unwrap();
+
+    assert_eq!(found_integration.id, created_integration.id);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn create() -> Result<(), sqlx::Error> {
+    let pool = PgPoolOptions::new()
+        .connect("postgres://jgayfer:@localhost/lfg")
+        .await?;
+    let mut repo = PsqlIntegrationRepo::new(pool);
+    let new_integration = TestNewIntegration::new().build();
+
+    let integration = repo.create(new_integration).await.unwrap();
+
+    assert_eq!(integration.success_url, "https://test-success.com");
+    assert_eq!(integration.webhook_url, "https://test-webhook.com");
+
+    Ok(())
+}


### PR DESCRIPTION
This is still pretty rough, but establishes a basic pattern of a Postgres repository, along with migrations.

Wanted to get it up for a look since there's a lot of "establishing" going on.

Some things I'd like to clean up before merge:
- Proper database config
- Better test database setup / cleaning between runs